### PR TITLE
merge이후 생긴 버그들 수정

### DIFF
--- a/Assets/C#/Contents/Area/AreaManager.cs
+++ b/Assets/C#/Contents/Area/AreaManager.cs
@@ -116,7 +116,7 @@ public class AreaManager
         _currentTile = _grid.GetTile(_grid.Width / 2, 0);
         for (int i = 0; i < 3; i++)
         {
-            GameObject player = Managers.ObjectMng.SpawnHero<Knight>(HERO_KNIGHT_ID).gameObject;
+            GameObject player = Managers.ObjectMng.SpawnHero(HERO_KNIGHT_ID).gameObject;
             player.transform.position = spawnOriginPos + new Vector3(HERO_SPAWN_POSITION_OFFSET[i].x, 0, HERO_SPAWN_POSITION_OFFSET[i].y);
             _players.Add(player);
         }

--- a/Assets/C#/Controllers/Creature.cs
+++ b/Assets/C#/Controllers/Creature.cs
@@ -268,13 +268,6 @@ public abstract class Creature : MonoBehaviour
         // TODO - 회복 애니메이션 실행
     }
 
-    public void OnHeal(int heal)
-    {
-        CreatureStat.OnHeal(heal);
-
-        // TODO - 회복 애니메이션 실행
-    }
-
     #endregion
 
 }

--- a/Assets/C#/Datas/DataContents.cs
+++ b/Assets/C#/Datas/DataContents.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using Unity.Netcode;
 using UnityEngine;
@@ -195,8 +195,6 @@ namespace Data
     [Serializable]
     public class SkillData : EquipmentData
     {
-        public int DataId;
-        public string Name;
         public string Description;
         public int CoinNum;
         public int ReducedStat;

--- a/Assets/C#/Managers/Contents/BattleManager.cs
+++ b/Assets/C#/Managers/Contents/BattleManager.cs
@@ -199,4 +199,5 @@ public class BattleManager
         }
         return false;
     }
+    #endregion
 }

--- a/Assets/Resources/Prefabs/Items/Item1.prefab
+++ b/Assets/Resources/Prefabs/Items/Item1.prefab
@@ -10,7 +10,6 @@ GameObject:
   m_Component:
   - component: {fileID: 8660616654493562854}
   - component: {fileID: 228868937137606814}
-  - component: {fileID: 1116885209790032800}
   m_Layer: 0
   m_Name: Item1
   m_TagString: Untagged
@@ -43,17 +42,5 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: f2fead6e80f4a644487106e7e0240c0d, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
---- !u!114 &1116885209790032800
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 6186117254946210380}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 5be31be1d25e3394c8283418d07b2dcd, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 

--- a/Assets/Resources/Prefabs/Items/SampleItem.prefab
+++ b/Assets/Resources/Prefabs/Items/SampleItem.prefab
@@ -10,7 +10,6 @@ GameObject:
   m_Component:
   - component: {fileID: 8667833139148809636}
   - component: {fileID: 6890549019024353969}
-  - component: {fileID: 1161596096630847772}
   m_Layer: 0
   m_Name: SampleItem
   m_TagString: Untagged
@@ -43,17 +42,5 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: f2fead6e80f4a644487106e7e0240c0d, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
---- !u!114 &1161596096630847772
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 8989054789550806363}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 54f1f370f57636a44a4282915df9e5c2, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 

--- a/Assets/Resources/Prefabs/Monsters/Dragon.prefab
+++ b/Assets/Resources/Prefabs/Monsters/Dragon.prefab
@@ -42,7 +42,6 @@ GameObject:
   m_Component:
   - component: {fileID: 5611543388551136099}
   - component: {fileID: 5611543388560993443}
-  - component: {fileID: 477688850574379416}
   m_Layer: 8
   m_Name: Dragon
   m_TagString: Monster
@@ -88,27 +87,6 @@ Animator:
   m_AllowConstantClipSamplingOptimization: 1
   m_KeepAnimatorStateOnDisable: 0
   m_WriteDefaultValuesOnDisable: 0
---- !u!114 &477688850574379416
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 5611543388551634691}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 871a379cd45f5bb4392e2f217ed238cb, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  _animState: 6
-  _turnState: 0
-  _lockTarget: {fileID: 0}
-  _stat:
-    _hp: 0
-    _maxHp: 0
-    _attack: 0
-    _defense: 0
-    _speed: 0
 --- !u!1 &5611543388551634693
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Resources/Prefabs/Monsters/EvilMage.prefab
+++ b/Assets/Resources/Prefabs/Monsters/EvilMage.prefab
@@ -1059,7 +1059,6 @@ GameObject:
   m_Component:
   - component: {fileID: 3972964382682190530}
   - component: {fileID: 3972964382691556668}
-  - component: {fileID: 2607789853073514248}
   m_Layer: 8
   m_Name: EvilMage
   m_TagString: Monster
@@ -1105,27 +1104,6 @@ Animator:
   m_AllowConstantClipSamplingOptimization: 1
   m_KeepAnimatorStateOnDisable: 0
   m_WriteDefaultValuesOnDisable: 0
---- !u!114 &2607789853073514248
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 3972964382682025698}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 871a379cd45f5bb4392e2f217ed238cb, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  _animState: 6
-  _turnState: 0
-  _lockTarget: {fileID: 0}
-  _stat:
-    _hp: 0
-    _maxHp: 0
-    _attack: 0
-    _defense: 0
-    _speed: 0
 --- !u!1 &3972964382682025700
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Resources/Prefabs/Monsters/Golem.prefab
+++ b/Assets/Resources/Prefabs/Monsters/Golem.prefab
@@ -1363,7 +1363,6 @@ GameObject:
   m_Component:
   - component: {fileID: 4191744185429214}
   - component: {fileID: 95246818704427922}
-  - component: {fileID: 8307621556009859632}
   m_Layer: 8
   m_Name: Golem
   m_TagString: Monster
@@ -1409,27 +1408,6 @@ Animator:
   m_AllowConstantClipSamplingOptimization: 1
   m_KeepAnimatorStateOnDisable: 0
   m_WriteDefaultValuesOnDisable: 0
---- !u!114 &8307621556009859632
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1706760125350986}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 871a379cd45f5bb4392e2f217ed238cb, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  _animState: 6
-  _turnState: 0
-  _lockTarget: {fileID: 0}
-  _stat:
-    _hp: 0
-    _maxHp: 0
-    _attack: 0
-    _defense: 0
-    _speed: 0
 --- !u!1 &1713691074708414
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Resources/Prefabs/Monsters/MonsterPlant.prefab
+++ b/Assets/Resources/Prefabs/Monsters/MonsterPlant.prefab
@@ -1365,7 +1365,6 @@ GameObject:
   m_Component:
   - component: {fileID: 4700302584741114}
   - component: {fileID: 95661104805808786}
-  - component: {fileID: 2487950194004813328}
   m_Layer: 8
   m_Name: MonsterPlant
   m_TagString: Monster
@@ -1411,27 +1410,6 @@ Animator:
   m_AllowConstantClipSamplingOptimization: 1
   m_KeepAnimatorStateOnDisable: 0
   m_WriteDefaultValuesOnDisable: 0
---- !u!114 &2487950194004813328
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1748489546896114}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 871a379cd45f5bb4392e2f217ed238cb, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  _animState: 6
-  _turnState: 0
-  _lockTarget: {fileID: 0}
-  _stat:
-    _hp: 0
-    _maxHp: 0
-    _attack: 0
-    _defense: 0
-    _speed: 0
 --- !u!1 &1781689967026810
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Resources/Prefabs/Monsters/Orc.prefab
+++ b/Assets/Resources/Prefabs/Monsters/Orc.prefab
@@ -1739,7 +1739,6 @@ GameObject:
   m_Component:
   - component: {fileID: 8511647367374981090}
   - component: {fileID: 8511647367367272476}
-  - component: {fileID: 4559411124329087285}
   m_Layer: 8
   m_Name: Orc
   m_TagString: Monster
@@ -1785,27 +1784,6 @@ Animator:
   m_AllowConstantClipSamplingOptimization: 1
   m_KeepAnimatorStateOnDisable: 0
   m_WriteDefaultValuesOnDisable: 0
---- !u!114 &4559411124329087285
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 8511647367374691266}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 871a379cd45f5bb4392e2f217ed238cb, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  _animState: 6
-  _turnState: 0
-  _lockTarget: {fileID: 0}
-  _stat:
-    _hp: 0
-    _maxHp: 0
-    _attack: 0
-    _defense: 0
-    _speed: 0
 --- !u!1 &8511647367374691268
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Resources/Prefabs/Monsters/Skeleton.prefab
+++ b/Assets/Resources/Prefabs/Monsters/Skeleton.prefab
@@ -588,7 +588,6 @@ GameObject:
   m_Component:
   - component: {fileID: 6285209290496798482}
   - component: {fileID: 6285209290506305774}
-  - component: {fileID: 8974564613426981673}
   m_Layer: 8
   m_Name: Skeleton
   m_TagString: Monster
@@ -634,27 +633,6 @@ Animator:
   m_AllowConstantClipSamplingOptimization: 1
   m_KeepAnimatorStateOnDisable: 0
   m_WriteDefaultValuesOnDisable: 0
---- !u!114 &8974564613426981673
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 6285209290496832306}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 871a379cd45f5bb4392e2f217ed238cb, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  _animState: 6
-  _turnState: 0
-  _lockTarget: {fileID: 0}
-  _stat:
-    _hp: 0
-    _maxHp: 0
-    _attack: 0
-    _defense: 0
-    _speed: 0
 --- !u!1 &6285209290496832308
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Resources/Prefabs/Monsters/Slime.prefab
+++ b/Assets/Resources/Prefabs/Monsters/Slime.prefab
@@ -424,7 +424,6 @@ GameObject:
   m_Component:
   - component: {fileID: 4047972025199878}
   - component: {fileID: 95457531584545886}
-  - component: {fileID: 895410296640428761}
   m_Layer: 8
   m_Name: Slime
   m_TagString: Monster
@@ -470,24 +469,3 @@ Animator:
   m_AllowConstantClipSamplingOptimization: 1
   m_KeepAnimatorStateOnDisable: 0
   m_WriteDefaultValuesOnDisable: 0
---- !u!114 &895410296640428761
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1931298151966786}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 871a379cd45f5bb4392e2f217ed238cb, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  _animState: 6
-  _turnState: 0
-  _lockTarget: {fileID: 0}
-  _stat:
-    _hp: 0
-    _maxHp: 0
-    _attack: 0
-    _defense: 0
-    _speed: 0

--- a/Assets/Resources/Prefabs/Monsters/Spider.prefab
+++ b/Assets/Resources/Prefabs/Monsters/Spider.prefab
@@ -649,7 +649,6 @@ GameObject:
   m_Component:
   - component: {fileID: 4843028258353612}
   - component: {fileID: 95690966028241422}
-  - component: {fileID: 67025140339233859}
   m_Layer: 8
   m_Name: Spider
   m_TagString: Monster
@@ -695,27 +694,6 @@ Animator:
   m_AllowConstantClipSamplingOptimization: 1
   m_KeepAnimatorStateOnDisable: 0
   m_WriteDefaultValuesOnDisable: 0
---- !u!114 &67025140339233859
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1557585983417840}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 871a379cd45f5bb4392e2f217ed238cb, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  _animState: 6
-  _turnState: 0
-  _lockTarget: {fileID: 0}
-  _stat:
-    _hp: 0
-    _maxHp: 0
-    _attack: 0
-    _defense: 0
-    _speed: 0
 --- !u!1 &1574160754023944
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Resources/Prefabs/Monsters/TurtleShell.prefab
+++ b/Assets/Resources/Prefabs/Monsters/TurtleShell.prefab
@@ -515,7 +515,6 @@ GameObject:
   m_Component:
   - component: {fileID: 4544219117696442}
   - component: {fileID: 95706204029656638}
-  - component: {fileID: 5411437605371046496}
   m_Layer: 8
   m_Name: TurtleShell
   m_TagString: Monster
@@ -561,27 +560,6 @@ Animator:
   m_AllowConstantClipSamplingOptimization: 1
   m_KeepAnimatorStateOnDisable: 0
   m_WriteDefaultValuesOnDisable: 0
---- !u!114 &5411437605371046496
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1524411113276028}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 871a379cd45f5bb4392e2f217ed238cb, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  _animState: 6
-  _turnState: 0
-  _lockTarget: {fileID: 0}
-  _stat:
-    _hp: 0
-    _maxHp: 0
-    _attack: 0
-    _defense: 0
-    _speed: 0
 --- !u!1 &1532652994627396
 GameObject:
   m_ObjectHideFlags: 0


### PR DESCRIPTION
몬스터, 아이템 프리팹의 컴포넌트로 붙어있던 스크립트가 MonoBehaviour가 아니게 되면서 생긴 오류 수정 (스크립트를 프리팹에서 제거)
Creature.cs의 OnHeal 메소드가 중복으로 있던 오류 수정
DataContents.cs의 SkillData에서 DataId와 Name 제거 - 부모인 EquipmentData에 이미 있어서 중복되어 오류 발생
BattleManager에 #endregion이 누락되어 있던 점 수정
AreaManager에서 히어로 스폰 코드 적절히 수정